### PR TITLE
chore: Group and automerge openmcp-project/build updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -28,9 +28,17 @@
       "rangeStrategy": "bump"
     },
     {
-      "description": "Automerge submodule update",
+      "description": "Group and automerge openmcp-project/build updates (GitHub Actions + hack/common submodule) into a single PR",
+      "groupName": "openmcp-project/build",
+      "groupSlug": "openmcp-build",
       "automerge": true,
-      "matchPackageNames": ["hack/common"]
+      "automergeType": "pr",
+      "matchManagers": ["github-actions", "git-submodules"],
+      "matchPackageNames": [
+        "hack/common",
+        "openmcp-project/build",
+        "/^openmcp-project/build/"
+      ]
     },
     {
       "description": "Update and automerge all components from openmcp-project immediately in one singe PR",


### PR DESCRIPTION
**What this PR does / why we need it**:
Group and automerge openmcp-project/build updates (GitHub Actions + hack/common submodule) into a single PR

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
